### PR TITLE
Moved inline styles to css file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Additional Notes
 This is the original Wordpress plugin with a few cosmetic changes.
+
 --dan-el
 
 # EsoSets Wordpress

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Additional Notes
+This is the original Wordpress plugin with a few cosmetic changes.
+--dan-el
+
 # EsoSets Wordpress
 
 Welcome to the eso-sets plugin for Wordpress. With this plugin you can show tooltips in Wordpress with gear set information about the Elder Scrolls Online. All data is directly pulled from https://eso-sets.com and https://eso-skillbook.com

--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-# Additional Notes
-This is the original Wordpress plugin with a few cosmetic changes.
-
---dan-el
-
 # EsoSets Wordpress
 
 Welcome to the eso-sets plugin for Wordpress. With this plugin you can show tooltips in Wordpress with gear set information about the Elder Scrolls Online. All data is directly pulled from https://eso-sets.com and https://eso-skillbook.com

--- a/eso-sets.php
+++ b/eso-sets.php
@@ -167,7 +167,7 @@ final class EsoSets
         $tooltip_5 = str_replace('"', "'", $result['skill_5']['tooltip']);
         $tooltip_ult = str_replace('"', "'", $result['skill_ult']['tooltip']);
 
-        $return = '<div align="center" style="margin-bottom:20px;">';
+        $return = '<div class="esoskill-skillbar">';
         $return .= '<a class="eso-set" href="https://www.eso-skillbook.com/skill/' . $atts['skill_1'] . '" target="_blank" ';
         if (isset($atts['tooltip']) && $atts['tooltip'] == 'true') {
             $return .= 'data-toggle="tooltip" ';

--- a/esosets_tooltips.css
+++ b/esosets_tooltips.css
@@ -1,6 +1,7 @@
 .tooltip-inner {
     max-width: 350px;
 }
+
 .esoset-tooltip {
     width: 100%;
     max-width: 350px;
@@ -36,6 +37,11 @@
     padding-bottom: 10px;
     margin-bottom: 5px;
 }
+
+.esoset-skillbar {
+    text-align: center;
+}
+
 .skill-img {
     margin-bottom: 5px;
     border-style: solid;
@@ -48,6 +54,7 @@
     -moz-border-right-colors: none;
     border-radius: 3px;
 }
+
 .passive-skill {
     border-radius: 35px;
 }

--- a/esosets_tooltips.css
+++ b/esosets_tooltips.css
@@ -38,8 +38,9 @@
     margin-bottom: 5px;
 }
 
-.esoset-skillbar {
+.esoskill-skillbar {
     text-align: center;
+    margin-bottom: 20px;
 }
 
 .skill-img {


### PR DESCRIPTION
Moved inline files to the css file. The added class allows better custom styling of the "skillbar" item through Wordpress stylesheets.